### PR TITLE
Update railties dependency to > 3.1

### DIFF
--- a/chart-js-rails.gemspec
+++ b/chart-js-rails.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Chart::Js::Rails::VERSION
 
-  gem.add_dependency "railties", "~> 3.1"
+  gem.add_dependency "railties", "> 3.1"
 end


### PR DESCRIPTION
Depending on `~> 3.1` prevents this gem from being used with Rails 4.
