### PR TITLE
Rename the module to ChartJs

### DIFF
--- a/chart-js-rails.gemspec
+++ b/chart-js-rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "chart-js-rails"
   gem.require_paths = ["lib"]
-  gem.version       = Chart::Js::Rails::VERSION
+  gem.version       = ChartJs::Rails::VERSION
 
   gem.add_dependency "railties", "~> 3.1"
 end

--- a/lib/chart-js-rails.rb
+++ b/lib/chart-js-rails.rb
@@ -1,6 +1,6 @@
 require 'chart-js-rails/version'
 
-module Chart
+module ChartJs
 	module Rails
 		class Engine < ::Rails::Engine
 		end

--- a/lib/chart-js-rails/version.rb
+++ b/lib/chart-js-rails/version.rb
@@ -1,7 +1,5 @@
-module Chart
-  module Js
-    module Rails
-      VERSION = "0.0.4"
-    end
-  end
+module ChartJs
+	module Rails
+		VERSION = "0.0.4"
+	end
 end


### PR DESCRIPTION
This renames the `Chart` module to `ChartJs`, which is much less likely to clash with a model name. (Why yes I am writing a charting tool in Rails.) Being a simple shim for the asset pipeline, I don't imagine that anyone is relying on the name of this module anyway.
